### PR TITLE
Bump python to 3.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.11"]
 
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
* Bumps python to 3.11
* Removes the testing matrix